### PR TITLE
convert all the "NAMES" to lower case -- prevents duplicate names such

### DIFF
--- a/diskstation_dns_modify.sh
+++ b/diskstation_dns_modify.sh
@@ -122,6 +122,7 @@ printDhcpAsRecords () {
         $1 == "dhcp-host" {IP=$4; NAME=$3; RENEW=$5}
         # If we have an IP and a NAME (and if name is not a placeholder)
         (IP != "" && NAME!="*" && NAME!="") {
+           NAME=tolower(NAME);
            split(IP,arr,".");
            ReverseIP = arr[4] "." arr[3] "." arr[2] "." arr[1];
            if(RecordType == "PTR" && index(StaticRecords, ReverseIP ".in-addr.arpa.," ) > 0) {IP="";}


### PR DESCRIPTION
as:

130.0.168.192.in-addr.arpa.	86400	PTR	Seans-iPad.devaudio.org.	;dynamic
130.0.168.192.in-addr.arpa.	86400	PTR	seans-ipad.devaudio.org.	;dynamic

as well as, like, having all the names be nice and lowercase and
consistent, no matter how they reported to dhcp